### PR TITLE
Update http link to https

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -21,10 +21,10 @@
   ~ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   -->
 
-<idea-plugin version="2">
+<idea-plugin>
     <id>com.eclectide.intellij.whatthecommit</id>
     <name>What The Commit</name>
-    <version>1.2</version>
+    <version>1.3</version>
     <vendor email="hello@darekkay.com" url="https://darekkay.com">Darek Kay</vendor>
 
     <description><![CDATA[
@@ -33,6 +33,10 @@
     ]]></description>
 
     <change-notes><![CDATA[
+    <p>1.3</p>
+    <ul>
+        <li>Change http link to https</li>
+    </ul>
     <p>1.2</p>
     <ul>
         <li>Add IntelliJ proxy support</li>

--- a/src/main/java/com/eclectide/intellij/whatthecommit/WhatTheCommitAction.java
+++ b/src/main/java/com/eclectide/intellij/whatthecommit/WhatTheCommitAction.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeoutException;
 
 public class WhatTheCommitAction extends AnAction implements DumbAware {
 
-    private static final String URL = "http://whatthecommit.com/index.txt";
+    private static final String URL = "https://whatthecommit.com/index.txt";
     private static final int TIMEOUT_SECONDS = 5;
 
     public void actionPerformed(@NotNull AnActionEvent e) {


### PR DESCRIPTION
The website moved host recently, and it appears the http link does not work anymore. I verified the https link works as expected.

Fixed version:
[What The Commit-1.3.zip](https://github.com/darekkay/what-the-commit/files/9989029/What.The.Commit-1.3.zip)
